### PR TITLE
Fix composer audit finding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "laravel/framework": "^12.0",
         "laravel/socialite": "^5.20",
         "laravel/tinker": "^2.10.1",
+        "league/commonmark": "^2.7",
         "spatie/laravel-translatable": "^6.11"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "340a08bfe76bb6a55619d3267a4d8c8a",
+    "content-hash": "ce141ab84ca07446181ee54d72c6419d",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -1824,16 +1824,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.6.2",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "06c3b0bf2540338094575612f4a1778d0d2d5e94"
+                "reference": "6fbb36d44824ed4091adbcf4c7d4a3923cdb3405"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/06c3b0bf2540338094575612f4a1778d0d2d5e94",
-                "reference": "06c3b0bf2540338094575612f4a1778d0d2d5e94",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/6fbb36d44824ed4091adbcf4c7d4a3923cdb3405",
+                "reference": "6fbb36d44824ed4091adbcf4c7d4a3923cdb3405",
                 "shasum": ""
             },
             "require": {
@@ -1870,7 +1870,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.7-dev"
+                    "dev-main": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1927,7 +1927,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-18T21:09:27+00:00"
+            "time": "2025-05-05T12:20:28+00:00"
         },
         {
             "name": "league/config",
@@ -9082,12 +9082,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "baktygul-site",
+    "name": "Fashion-Services",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
## Summary
- update league/commonmark to ^2.7 to resolve audit notice
- run composer and npm audits

## Testing
- `composer audit --format=json`
- `npm audit --json`
- `php vendor/bin/phpunit` *(fails: could not find driver / 405 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841cd08e2e08328aa1021e93fbc1855